### PR TITLE
Allow id to be specified in the request to override default

### DIFF
--- a/Aria2.JsonRpcClient/Aria2Client.cs
+++ b/Aria2.JsonRpcClient/Aria2Client.cs
@@ -29,23 +29,23 @@ namespace Aria2.JsonRpcClient
         #region Download Adding Methods
 
         /// <inheritdoc/>
-        public Task<string> AddUri(string[] uris, Aria2DownloadOptions? options = null, int? position = null)
+        public Task<string> AddUri(string[] uris, Aria2DownloadOptions? options = null, int? position = null, string? id = null)
         {
-            var request = new AddUri(uris, options, position);
+            var request = new AddUri(uris, options, position, id);
             return ExecuteRequest<string>(request);
         }
 
         /// <inheritdoc/>
-        public Task<string> AddTorrent(string torrent, Aria2DownloadOptions? options = null, int? position = null)
+        public Task<string> AddTorrent(string torrent, Aria2DownloadOptions? options = null, int? position = null, string? id = null)
         {
-            var request = new AddTorrent(torrent, options, position);
+            var request = new AddTorrent(torrent, options, position, id);
             return ExecuteRequest<string>(request);
         }
 
         /// <inheritdoc/>
-        public Task<string> AddMetalink(string metalink, Aria2DownloadOptions? options = null, int? position = null)
+        public Task<string> AddMetalink(string metalink, Aria2DownloadOptions? options = null, int? position = null, string? id = null)
         {
-            var request = new AddMetalink(metalink, options, position);
+            var request = new AddMetalink(metalink, options, position, id);
             return ExecuteRequest<string>(request);
         }
 
@@ -54,58 +54,58 @@ namespace Aria2.JsonRpcClient
         #region Download Removal & Pause Methods
 
         /// <inheritdoc/>
-        public Task<string> Remove(string gid)
+        public Task<string> Remove(string gid, string? id = null)
         {
-            var request = new Remove(gid);
+            var request = new Remove(gid, id);
             return ExecuteRequest<string>(request);
         }
 
         /// <inheritdoc/>
-        public Task<string> ForceRemove(string gid)
+        public Task<string> ForceRemove(string gid, string? id = null)
         {
-            var request = new ForceRemove(gid);
+            var request = new ForceRemove(gid, id);
             return ExecuteRequest<string>(request);
         }
 
         /// <inheritdoc/>
-        public Task<string> Pause(string gid)
+        public Task<string> Pause(string gid, string? id = null)
         {
-            var request = new Pause(gid);
+            var request = new Pause(gid, id);
             return ExecuteRequest<string>(request);
         }
 
         /// <inheritdoc/>
-        public Task PauseAll()
+        public Task PauseAll(string? id = null)
         {
-            var request = new PauseAll();
+            var request = new PauseAll(id);
             return ExecuteRequest(request);
         }
 
         /// <inheritdoc/>
-        public Task<string> ForcePause(string gid)
+        public Task<string> ForcePause(string gid, string? id = null)
         {
-            var request = new ForcePause(gid);
+            var request = new ForcePause(gid, id);
             return ExecuteRequest<string>(request);
         }
 
         /// <inheritdoc/>
-        public Task ForcePauseAll()
+        public Task ForcePauseAll(string? id = null)
         {
-            var request = new ForcePauseAll();
+            var request = new ForcePauseAll(id);
             return ExecuteRequest(request);
         }
 
         /// <inheritdoc/>
-        public Task<string> Unpause(string gid)
+        public Task<string> Unpause(string gid, string? id = null)
         {
-            var request = new Unpause(gid);
+            var request = new Unpause(gid, id);
             return ExecuteRequest<string>(request);
         }
 
         /// <inheritdoc/>
-        public Task UnpauseAll()
+        public Task UnpauseAll(string? id = null)
         {
-            var request = new UnpauseAll();
+            var request = new UnpauseAll(id);
             return ExecuteRequest(request);
         }
 
@@ -114,58 +114,58 @@ namespace Aria2.JsonRpcClient
         #region Download Status & Information Methods
 
         /// <inheritdoc/>
-        public Task<Aria2Status> TellStatus(string gid, string[]? keys = null)
+        public Task<Aria2Status> TellStatus(string gid, string[]? keys = null, string? id = null)
         {
-            var request = new TellStatus(gid, keys);
+            var request = new TellStatus(gid, keys, id);
             return ExecuteRequest<Aria2Status>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<Aria2Uri>> GetUris(string gid)
+        public Task<IReadOnlyList<Aria2Uri>> GetUris(string gid, string? id = null)
         {
-            var request = new GetUris(gid);
+            var request = new GetUris(gid, id);
             return ExecuteRequest<IReadOnlyList<Aria2Uri>>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<Aria2File>> GetFiles(string gid)
+        public Task<IReadOnlyList<Aria2File>> GetFiles(string gid, string? id = null)
         {
-            var request = new GetFiles(gid);
+            var request = new GetFiles(gid, id);
             return ExecuteRequest<IReadOnlyList<Aria2File>>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<Aria2Peer>> GetPeers(string gid)
+        public Task<IReadOnlyList<Aria2Peer>> GetPeers(string gid, string? id = null)
         {
-            var request = new GetPeers(gid);
+            var request = new GetPeers(gid, id);
             return ExecuteRequest<IReadOnlyList<Aria2Peer>>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<Aria2Server>> GetServers(string gid)
+        public Task<IReadOnlyList<Aria2Server>> GetServers(string gid, string? id = null)
         {
-            var request = new GetServers(gid);
+            var request = new GetServers(gid, id);
             return ExecuteRequest<IReadOnlyList<Aria2Server>>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<Aria2Status>> TellActive(string[]? keys = null)
+        public Task<IReadOnlyList<Aria2Status>> TellActive(string[]? keys = null, string? id = null)
         {
-            var request = new TellActive(keys);
+            var request = new TellActive(keys, id);
             return ExecuteRequest<IReadOnlyList<Aria2Status>>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<Aria2Status>> TellWaiting(int offset, int num, string[]? keys = null)
+        public Task<IReadOnlyList<Aria2Status>> TellWaiting(int offset, int num, string[]? keys = null, string? id = null)
         {
-            var request = new TellWaiting(offset, num, keys);
+            var request = new TellWaiting(offset, num, keys, id);
             return ExecuteRequest<IReadOnlyList<Aria2Status>>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<Aria2Status>> TellStopped(int offset, int num, string[]? keys = null)
+        public Task<IReadOnlyList<Aria2Status>> TellStopped(int offset, int num, string[]? keys = null, string? id = null)
         {
-            var request = new TellStopped(offset, num, keys);
+            var request = new TellStopped(offset, num, keys, id);
             return ExecuteRequest<IReadOnlyList<Aria2Status>>(request);
         }
 
@@ -174,16 +174,16 @@ namespace Aria2.JsonRpcClient
         #region Download Modification Methods
 
         /// <inheritdoc/>
-        public Task<int> ChangePosition(string gid, int pos, string how)
+        public Task<int> ChangePosition(string gid, int pos, string how, string? id = null)
         {
-            var request = new ChangePosition(gid, pos, how);
+            var request = new ChangePosition(gid, pos, how, id);
             return ExecuteRequest<int>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<int>> ChangeUri(string gid, int fileIndex, IEnumerable<string> delUris, IEnumerable<string> addUris, int? position = null)
+        public Task<IReadOnlyList<int>> ChangeUri(string gid, int fileIndex, IEnumerable<string> delUris, IEnumerable<string> addUris, int? position = null, string? id = null)
         {
-            var request = new ChangeUri(gid, fileIndex, delUris, addUris, position);
+            var request = new ChangeUri(gid, fileIndex, delUris, addUris, position, id);
             return ExecuteRequest<IReadOnlyList<int>>(request);
         }
 
@@ -192,30 +192,30 @@ namespace Aria2.JsonRpcClient
         #region Option Methods
 
         /// <inheritdoc/>
-        public Task<Aria2Option> GetOption(string gid)
+        public Task<Aria2Option> GetOption(string gid, string? id = null)
         {
-            var request = new GetOption(gid);
+            var request = new GetOption(gid, id);
             return ExecuteRequest<Aria2Option>(request);
         }
 
         /// <inheritdoc/>
-        public Task ChangeOption(string gid, Aria2DownloadOptions options)
+        public Task ChangeOption(string gid, Aria2DownloadOptions options, string? id = null)
         {
-            var request = new ChangeOption(gid, options);
+            var request = new ChangeOption(gid, options, id);
             return ExecuteRequest(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyDictionary<string, string?>> GetGlobalOption()
+        public Task<IReadOnlyDictionary<string, string?>> GetGlobalOption(string? id = null)
         {
-            var request = new GetGlobalOption();
+            var request = new GetGlobalOption(id);
             return ExecuteRequest<IReadOnlyDictionary<string, string?>>(request);
         }
 
         /// <inheritdoc/>
-        public Task ChangeGlobalOption(Aria2DownloadOptions options)
+        public Task ChangeGlobalOption(Aria2DownloadOptions options, string? id = null)
         {
-            var request = new ChangeGlobalOption(options);
+            var request = new ChangeGlobalOption(options, id);
             return ExecuteRequest(request);
         }
 
@@ -224,58 +224,58 @@ namespace Aria2.JsonRpcClient
         #region Global Status & Miscellaneous Methods
 
         /// <inheritdoc/>
-        public Task<Aria2GlobalStat> GetGlobalStat()
+        public Task<Aria2GlobalStat> GetGlobalStat(string? id = null)
         {
-            var request = new GetGlobalStat();
+            var request = new GetGlobalStat(id);
             return ExecuteRequest<Aria2GlobalStat>(request);
         }
 
         /// <inheritdoc/>
-        public Task<Aria2Version> GetVersion()
+        public Task<Aria2Version> GetVersion(string? id = null)
         {
-            var request = new GetVersion();
+            var request = new GetVersion(id);
             return ExecuteRequest<Aria2Version>(request);
         }
 
         /// <inheritdoc/>
-        public Task<Aria2SessionInfo> GetSessionInfo()
+        public Task<Aria2SessionInfo> GetSessionInfo(string? id = null)
         {
-            var request = new GetSessionInfo();
+            var request = new GetSessionInfo(id);
             return ExecuteRequest<Aria2SessionInfo>(request);
         }
 
         /// <inheritdoc/>
-        public Task Shutdown()
+        public Task Shutdown(string? id = null)
         {
-            var request = new Shutdown();
+            var request = new Shutdown(id);
             return ExecuteRequest(request);
         }
 
         /// <inheritdoc/>
-        public Task ForceShutdown()
+        public Task ForceShutdown(string? id = null)
         {
-            var request = new ForceShutdown();
+            var request = new ForceShutdown(id);
             return ExecuteRequest(request);
         }
 
         /// <inheritdoc/>
-        public Task SaveSession()
+        public Task SaveSession(string? id = null)
         {
-            var request = new SaveSession();
+            var request = new SaveSession(id);
             return ExecuteRequest(request);
         }
 
         /// <inheritdoc/>
-        public Task PurgeDownloadResult()
+        public Task PurgeDownloadResult(string? id = null)
         {
-            var request = new PurgeDownloadResult();
+            var request = new PurgeDownloadResult(id);
             return ExecuteRequest(request);
         }
 
         /// <inheritdoc/>
-        public Task RemoveDownloadResult(string gid)
+        public Task RemoveDownloadResult(string gid, string? id = null)
         {
-            var request = new RemoveDownloadResult(gid);
+            var request = new RemoveDownloadResult(gid, id);
             return ExecuteRequest(request);
         }
 
@@ -284,7 +284,13 @@ namespace Aria2.JsonRpcClient
         #region System Methods
 
         /// <inheritdoc/>
-        public async Task<IReadOnlyList<object?>> SystemMulticall(params JsonRpcRequest[] methods)
+        public Task<IReadOnlyList<object?>> SystemMulticall(params JsonRpcRequest[] methods)
+        {
+            return SystemMulticall(methods, null);
+        }
+
+        /// <inheritdoc/>
+        public async Task<IReadOnlyList<object?>> SystemMulticall(JsonRpcRequest[] methods, string? id = null)
         {
             var request = new MultiCall(methods);
             var results = await ExecuteRequest<IReadOnlyList<JsonElement[]>>(request);
@@ -310,16 +316,16 @@ namespace Aria2.JsonRpcClient
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<string>> SystemListMethods()
+        public Task<IReadOnlyList<string>> SystemListMethods(string? id = null)
         {
-            var request = new ListMethods();
+            var request = new ListMethods(id);
             return ExecuteRequest<IReadOnlyList<string>>(request);
         }
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<string>> SystemListNotifications()
+        public Task<IReadOnlyList<string>> SystemListNotifications(string? id = null)
         {
-            var request = new ListNotifications();
+            var request = new ListNotifications(id);
             return ExecuteRequest<IReadOnlyList<string>>(request);
         }
 
@@ -331,7 +337,7 @@ namespace Aria2.JsonRpcClient
         {
             if (typeof(T) != request.ReturnType)
             {
-                throw new ArgumentException("The return type of the request does not match the specified type.", nameof(T));
+                throw new ArgumentException("The return type of the request does not match the specified type.", nameof(request));
             }
             var response = await _requestHandler.SendRequest<T>(request);
             return EnsureSuccessResponse(response);
@@ -390,7 +396,7 @@ namespace Aria2.JsonRpcClient
 
             if (response.Result is null)
             {
-                throw new Exception("Invalid JSON-RPC response.");
+                throw new InvalidOperationException("Invalid JSON-RPC response.");
             }
 
             return response.Result;

--- a/Aria2.JsonRpcClient/IAria2Client.cs
+++ b/Aria2.JsonRpcClient/IAria2Client.cs
@@ -20,9 +20,10 @@ namespace Aria2.JsonRpcClient
         /// <param name="uris">An array of URIs pointing to the same resource.</param>
         /// <param name="options">Download options.</param>
         /// <param name="position">The position in the waiting queue to insert the download.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.addUri"/>
         /// <returns>The GID of the newly registered download.</returns>
-        Task<string> AddUri(string[] uris, Aria2DownloadOptions? options = null, int? position = null);
+        Task<string> AddUri(string[] uris, Aria2DownloadOptions? options = null, int? position = null, string? id = null);
 
         /// <summary>
         /// Adds a new BitTorrent download by uploading a torrent file (base64 encoded).
@@ -33,9 +34,10 @@ namespace Aria2.JsonRpcClient
         /// <param name="torrent">A base64 encoded torrent file.</param>
         /// <param name="options">Download options.</param>
         /// <param name="position">The position in the waiting queue to insert the download.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.addTorrent"/>
         /// <returns>The GID of the newly registered download.</returns>
-        Task<string> AddTorrent(string torrent, Aria2DownloadOptions? options = null, int? position = null);
+        Task<string> AddTorrent(string torrent, Aria2DownloadOptions? options = null, int? position = null, string? id = null);
 
         /// <summary>
         /// Adds new downloads from a Metalink file (base64 encoded).
@@ -46,9 +48,10 @@ namespace Aria2.JsonRpcClient
         /// <param name="metalink">A base64 encoded Metalink file.</param>
         /// <param name="options">Download options.</param>
         /// <param name="position">The position in the waiting queue to insert the downloads.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.addMetalink"/>
         /// <returns>The GID of the newly registered download.</returns>
-        Task<string> AddMetalink(string metalink, Aria2DownloadOptions? options = null, int? position = null);
+        Task<string> AddMetalink(string metalink, Aria2DownloadOptions? options = null, int? position = null, string? id = null);
 
         #endregion Download Adding Methods
 
@@ -60,66 +63,74 @@ namespace Aria2.JsonRpcClient
         /// Returns the GID of the removed download.
         /// </summary>
         /// <param name="gid">The GID of the download to remove.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.remove"/>
         /// <returns>The GID of the removed download.</returns>
-        Task<string> Remove(string gid);
+        Task<string> Remove(string gid, string? id = null);
 
         /// <summary>
         /// Forcefully removes the download denoted by <paramref name="gid"/> from the download queue without performing time‑consuming actions.
         /// Returns the GID of the removed download.
         /// </summary>
         /// <param name="gid">The GID of the download to forcefully remove.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.forceRemove"/>
         /// <returns>The GID of the removed download.</returns>
-        Task<string> ForceRemove(string gid);
+        Task<string> ForceRemove(string gid, string? id = null);
 
         /// <summary>
         /// Pauses the download denoted by <paramref name="gid"/>.
         /// Returns the GID of the paused download.
         /// </summary>
         /// <param name="gid">The GID of the download to pause.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.pause"/>
         /// <returns>The GID of the paused download.</returns>
-        Task<string> Pause(string gid);
+        Task<string> Pause(string gid, string? id = null);
 
         /// <summary>
         /// Pauses all active and waiting downloads.
         /// Returns "OK" upon success.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.pauseAll"/>
-        Task PauseAll();
+        Task PauseAll(string? id = null);
 
         /// <summary>
         /// Forcefully pauses the download denoted by <paramref name="gid"/> without performing extra actions.
         /// Returns the GID of the paused download.
         /// </summary>
         /// <param name="gid">The GID of the download to forcefully pause.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.forcePause"/>
         /// <returns>The GID of the paused download.</returns>
-        Task<string> ForcePause(string gid);
+        Task<string> ForcePause(string gid, string? id = null);
 
         /// <summary>
         /// Forcefully pauses all active and waiting downloads without extra actions.
         /// Returns "OK" upon success.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.forcePauseAll"/>
-        Task ForcePauseAll();
+        Task ForcePauseAll(string? id = null);
 
         /// <summary>
         /// Unpauses the download denoted by <paramref name="gid"/>, changing its status to waiting.
         /// Returns the GID of the unpaused download.
         /// </summary>
         /// <param name="gid">The GID of the download to unpause.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.unpause"/>
         /// <returns>The GID of the unpaused download.</returns>
-        Task<string> Unpause(string gid);
+        Task<string> Unpause(string gid, string? id = null);
 
         /// <summary>
         /// Unpauses all paused downloads.
         /// Returns "OK" upon success.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.unpauseAll"/>
-        Task UnpauseAll();
+        Task UnpauseAll(string? id = null);
 
         #endregion Download Removal & Pause Methods
 
@@ -132,54 +143,60 @@ namespace Aria2.JsonRpcClient
         /// </summary>
         /// <param name="gid">The GID of the download.</param>
         /// <param name="keys">An optional array of keys to filter the response.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.tellStatus"/>
         /// <returns>An <see cref="Aria2Status"/> object describing the download's status.</returns>
-        Task<Aria2Status> TellStatus(string gid, string[]? keys = null);
+        Task<Aria2Status> TellStatus(string gid, string[]? keys = null, string? id = null);
 
         /// <summary>
         /// Returns an array of URI objects used by the download denoted by <paramref name="gid"/>.
         /// Each URI object contains the URI and its status.
         /// </summary>
         /// <param name="gid">The GID of the download.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getUris"/>
         /// <returns>A read-only list of <see cref="Aria2Uri"/> objects.</returns>
-        Task<IReadOnlyList<Aria2Uri>> GetUris(string gid);
+        Task<IReadOnlyList<Aria2Uri>> GetUris(string gid, string? id = null);
 
         /// <summary>
         /// Returns an array of file objects associated with the download denoted by <paramref name="gid"/>.
         /// Each file object includes details such as file path, size, and progress.
         /// </summary>
         /// <param name="gid">The GID of the download.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getFiles"/>
         /// <returns>A read-only list of <see cref="Aria2File"/> objects.</returns>
-        Task<IReadOnlyList<Aria2File>> GetFiles(string gid);
+        Task<IReadOnlyList<Aria2File>> GetFiles(string gid, string? id = null);
 
         /// <summary>
         /// Returns an array of peer objects associated with the download denoted by <paramref name="gid"/>.
         /// Each peer object contains details such as IP address, port, and speed information.
         /// </summary>
         /// <param name="gid">The GID of the download.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getPeers"/>
         /// <returns>A read-only list of <see cref="Aria2Peer"/> objects.</returns>
-        Task<IReadOnlyList<Aria2Peer>> GetPeers(string gid);
+        Task<IReadOnlyList<Aria2Peer>> GetPeers(string gid, string? id = null);
 
         /// <summary>
         /// Returns a list of currently connected servers for the download denoted by <paramref name="gid"/>.
         /// Each server object contains the original URI, current URI, and download speed.
         /// </summary>
         /// <param name="gid">The GID of the download.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getServers"/>
         /// <returns>A read-only list of <see cref="Aria2Server"/> objects.</returns>
-        Task<IReadOnlyList<Aria2Server>> GetServers(string gid);
+        Task<IReadOnlyList<Aria2Server>> GetServers(string gid, string? id = null);
 
         /// <summary>
         /// Returns a list of active downloads.
         /// Each download's status is represented as an <see cref="Aria2Status"/> object.
         /// </summary>
         /// <param name="keys">Optional keys to filter the status objects.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.tellActive"/>
         /// <returns>A read-only list of active downloads.</returns>
-        Task<IReadOnlyList<Aria2Status>> TellActive(string[]? keys = null);
+        Task<IReadOnlyList<Aria2Status>> TellActive(string[]? keys = null, string? id = null);
 
         /// <summary>
         /// Returns a list of waiting downloads.
@@ -188,9 +205,10 @@ namespace Aria2.JsonRpcClient
         /// <param name="offset">The starting index in the waiting queue.</param>
         /// <param name="num">The maximum number of downloads to return.</param>
         /// <param name="keys">Optional keys to filter the status objects.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.tellWaiting"/>
         /// <returns>A read-only list of waiting downloads.</returns>
-        Task<IReadOnlyList<Aria2Status>> TellWaiting(int offset, int num, string[]? keys = null);
+        Task<IReadOnlyList<Aria2Status>> TellWaiting(int offset, int num, string[]? keys = null, string? id = null);
 
         /// <summary>
         /// Returns a list of stopped downloads.
@@ -199,9 +217,10 @@ namespace Aria2.JsonRpcClient
         /// <param name="offset">The starting index in the stopped queue.</param>
         /// <param name="num">The maximum number of downloads to return.</param>
         /// <param name="keys">Optional keys to filter the status objects.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.tellStopped"/>
         /// <returns>A read-only list of stopped downloads.</returns>
-        Task<IReadOnlyList<Aria2Status>> TellStopped(int offset, int num, string[]? keys = null);
+        Task<IReadOnlyList<Aria2Status>> TellStopped(int offset, int num, string[]? keys = null, string? id = null);
 
         #endregion Download Status & Information Methods
 
@@ -215,9 +234,10 @@ namespace Aria2.JsonRpcClient
         /// <param name="gid">The GID of the download.</param>
         /// <param name="pos">The position value.</param>
         /// <param name="how">The mode of repositioning.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.changePosition"/>
         /// <returns>The new position.</returns>
-        Task<int> ChangePosition(string gid, int pos, string how);
+        Task<int> ChangePosition(string gid, int pos, string how, string? id = null);
 
         /// <summary>
         /// Removes URIs specified in <paramref name="delUris"/> and appends URIs in <paramref name="addUris"/> for the download (and file index) denoted by <paramref name="gid"/>.
@@ -229,9 +249,10 @@ namespace Aria2.JsonRpcClient
         /// <param name="delUris">List of URIs to remove.</param>
         /// <param name="addUris">List of URIs to add.</param>
         /// <param name="position">Optional insertion position (0-based) after deletion.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.changeUri"/>
         /// <returns>An array of two integers: [number deleted, number added].</returns>
-        Task<IReadOnlyList<int>> ChangeUri(string gid, int fileIndex, IEnumerable<string> delUris, IEnumerable<string> addUris, int? position = null);
+        Task<IReadOnlyList<int>> ChangeUri(string gid, int fileIndex, IEnumerable<string> delUris, IEnumerable<string> addUris, int? position = null, string? id = null);
 
         #endregion Download Modification Methods
 
@@ -242,9 +263,10 @@ namespace Aria2.JsonRpcClient
         /// Only options that have been set or have defaults are returned.
         /// </summary>
         /// <param name="gid">The GID of the download.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getOption"/>
         /// <returns>An <see cref="Aria2Option"/> object with the download's options.</returns>
-        Task<Aria2Option> GetOption(string gid);
+        Task<Aria2Option> GetOption(string gid, string? id = null);
 
         /// <summary>
         /// Changes the options for the download denoted by <paramref name="gid"/>.
@@ -253,16 +275,18 @@ namespace Aria2.JsonRpcClient
         /// </summary>
         /// <param name="gid">The GID of the download to modify.</param>
         /// <param name="options">The options to change.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.changeOption"/>
-        Task ChangeOption(string gid, Aria2DownloadOptions options);
+        Task ChangeOption(string gid, Aria2DownloadOptions options, string? id = null);
 
         /// <summary>
         /// Returns the global options as a struct.
         /// Only options that have been set or have defaults are returned.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getGlobalOption"/>
         /// <returns>A dictionary of global options.</returns>
-        Task<IReadOnlyDictionary<string, string?>> GetGlobalOption();
+        Task<IReadOnlyDictionary<string, string?>> GetGlobalOption(string? id = null);
 
         /// <summary>
         /// Changes the global options dynamically.
@@ -270,8 +294,9 @@ namespace Aria2.JsonRpcClient
         /// Returns "OK" upon success.
         /// </summary>
         /// <param name="options">The global options to change.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.changeGlobalOption"/>
-        Task ChangeGlobalOption(Aria2DownloadOptions options);
+        Task ChangeGlobalOption(Aria2DownloadOptions options, string? id = null);
 
         #endregion Option Methods
 
@@ -281,59 +306,67 @@ namespace Aria2.JsonRpcClient
         /// Returns global statistics for the aria2 session.
         /// The returned struct includes overall download/upload speeds and counts of active, waiting, and stopped downloads.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getGlobalStat"/>
         /// <returns>An <see cref="Aria2GlobalStat"/> object with global statistics.</returns>
-        Task<Aria2GlobalStat> GetGlobalStat();
+        Task<Aria2GlobalStat> GetGlobalStat(string? id = null);
 
         /// <summary>
         /// Returns version information of aria2, including enabled features.
         /// </summary>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getVersion"/>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <returns>An <see cref="Aria2Version"/> object with version information.</returns>
-        Task<Aria2Version> GetVersion();
+        Task<Aria2Version> GetVersion(string? id = null);
 
         /// <summary>
         /// Returns session information of the current aria2 session, including the session ID.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.getSessionInfo"/>
         /// <returns>An <see cref="Aria2SessionInfo"/> object with session information.</returns>
-        Task<Aria2SessionInfo> GetSessionInfo();
+        Task<Aria2SessionInfo> GetSessionInfo(string? id = null);
 
         /// <summary>
         /// Gracefully shuts down aria2, allowing active downloads to complete.
         /// Returns "OK" upon success.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.shutdown"/>
-        Task Shutdown();
+        Task Shutdown(string? id = null);
 
         /// <summary>
         /// Forcefully shuts down aria2 immediately without waiting for active downloads.
         /// Returns "OK" upon success.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.forceShutdown"/>
-        Task ForceShutdown();
+        Task ForceShutdown(string? id = null);
 
         /// <summary>
         /// Saves the current session to a file specified by the --save-session option.
         /// Returns "OK" upon success.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.saveSession"/>
-        Task SaveSession();
+        Task SaveSession(string? id = null);
 
         /// <summary>
         /// Purges completed, error, or removed downloads from memory.
         /// Returns "OK" upon success.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.purgeDownloadResult"/>
-        Task PurgeDownloadResult();
+        Task PurgeDownloadResult(string? id = null);
 
         /// <summary>
         /// Removes a download result (completed/error/removed) from memory, identified by <paramref name="gid"/>.
         /// Returns "OK" upon success.
         /// </summary>
         /// <param name="gid">The GID of the download result to remove.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#aria2.removeDownloadResult"/>
-        Task RemoveDownloadResult(string gid);
+        Task RemoveDownloadResult(string gid, string? id = null);
 
         #endregion Global Status & Miscellaneous Methods
 
@@ -350,18 +383,31 @@ namespace Aria2.JsonRpcClient
         Task<IReadOnlyList<object?>> SystemMulticall(params JsonRpcRequest[] methods);
 
         /// <summary>
+        /// Encapsulates multiple method calls in a single request.
+        /// <paramref name="methods"/> is an array of <see cref="JsonRpcRequest"/>.
+        /// Returns an array of responses.
+        /// </summary>
+        /// <param name="methods">A list of method calls to execute.</param>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
+        /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#system.multicall"/>
+        /// <returns>A list of responses for the method calls.</returns>
+        Task<IReadOnlyList<object?>> SystemMulticall(JsonRpcRequest[] methods, string? id = null);
+
+        /// <summary>
         /// Returns an array of all available RPC method names.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#system.listMethods"/>
         /// <returns>A list of method names.</returns>
-        Task<IReadOnlyList<string>> SystemListMethods();
+        Task<IReadOnlyList<string>> SystemListMethods(string? id = null);
 
         /// <summary>
         /// Returns an array of all available RPC notification names.
         /// </summary>
+        /// <param name="id">The tracking id for the request. If this is omitted it will be generated automatically.</param>
         /// <seealso href="https://aria2.github.io/manual/en/html/aria2c.html#system.listNotifications"/>
         /// <returns>A list of notification names.</returns>
-        Task<IReadOnlyList<string>> SystemListNotifications();
+        Task<IReadOnlyList<string>> SystemListNotifications(string? id = null);
 
         #endregion System Methods
 

--- a/Aria2.JsonRpcClient/Requests/AddMetalink.cs
+++ b/Aria2.JsonRpcClient/Requests/AddMetalink.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record AddMetalink : JsonRpcRequest<string>
     {
-        /// <inheritdoc cref="IAria2Client.AddMetalink(string, Aria2DownloadOptions?, int?)"/>
-        public AddMetalink(string metalink, Aria2DownloadOptions? options = null, int? position = null) : base("aria2.addMetalink", [metalink, options, position])
+        /// <inheritdoc cref="IAria2Client.AddMetalink"/>
+        public AddMetalink(string metalink, Aria2DownloadOptions? options = null, int? position = null, string? id = null) : base("aria2.addMetalink", [metalink, options, position], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/AddTorrent.cs
+++ b/Aria2.JsonRpcClient/Requests/AddTorrent.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record AddTorrent : JsonRpcRequest<string>
     {
-        /// <inheritdoc cref="IAria2Client.AddTorrent(string, Aria2DownloadOptions?, int?)"/>
-        public AddTorrent(string torrent, Aria2DownloadOptions? options = null, int? position = null) : base("aria2.addTorrent", [torrent, options, position])
+        /// <inheritdoc cref="IAria2Client.AddTorrent"/>
+        public AddTorrent(string torrent, Aria2DownloadOptions? options = null, int? position = null, string? id = null) : base("aria2.addTorrent", [torrent, options, position], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/AddUri.cs
+++ b/Aria2.JsonRpcClient/Requests/AddUri.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record AddUri : JsonRpcRequest<string>
     {
-        /// <inheritdoc cref="IAria2Client.AddUri(string[], Aria2DownloadOptions?, int?)"/>
-        public AddUri(string[] uris, Aria2DownloadOptions? options = null, int? position = null) : base("aria2.addUri", [uris, options, position])
+        /// <inheritdoc cref="IAria2Client.AddUri"/>
+        public AddUri(string[] uris, Aria2DownloadOptions? options = null, int? position = null, string? id = null) : base("aria2.addUri", [uris, options, position], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ChangeGlobalOption.cs
+++ b/Aria2.JsonRpcClient/Requests/ChangeGlobalOption.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record ChangeGlobalOption : JsonRpcRequest
     {
-        /// <inheritdoc cref="IAria2Client.ChangeGlobalOption(Aria2DownloadOptions)"/>
-        public ChangeGlobalOption(Aria2DownloadOptions options) : base("aria2.changeGlobalOption", [options])
+        /// <inheritdoc cref="IAria2Client.ChangeGlobalOption"/>
+        public ChangeGlobalOption(Aria2DownloadOptions options, string? id = null) : base("aria2.changeGlobalOption", [options], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ChangeOption.cs
+++ b/Aria2.JsonRpcClient/Requests/ChangeOption.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record ChangeOption : JsonRpcRequest
     {
-        /// <inheritdoc cref="IAria2Client.ChangeOption(string, Aria2DownloadOptions)"/>
-        public ChangeOption(string gid, Aria2DownloadOptions options) : base("aria2.changeOption", [gid, options])
+        /// <inheritdoc cref="IAria2Client.ChangeOption"/>
+        public ChangeOption(string gid, Aria2DownloadOptions options, string? id = null) : base("aria2.changeOption", [gid, options], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ChangePosition.cs
+++ b/Aria2.JsonRpcClient/Requests/ChangePosition.cs
@@ -6,8 +6,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record ChangePosition : JsonRpcRequest<int>
     {
-        /// <inheritdoc cref="IAria2Client.ChangePosition(string, int, string)"/>
-        public ChangePosition(string gid, int pos, string how) : base("aria2.changePosition", [gid, pos, how])
+        /// <inheritdoc cref="IAria2Client.ChangePosition"/>
+        public ChangePosition(string gid, int pos, string how, string? id = null) : base("aria2.changePosition", [gid, pos, how], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ChangeUri.cs
+++ b/Aria2.JsonRpcClient/Requests/ChangeUri.cs
@@ -5,8 +5,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record ChangeUri : JsonRpcRequest<IReadOnlyList<int>>
     {
-        /// <inheritdoc cref="IAria2Client.ChangeUri(string, int, IEnumerable{string}, IEnumerable{string}, int?)"/>
-        public ChangeUri(string gid, int fileIndex, IEnumerable<string> delUris, IEnumerable<string> addUris, int? position = null) : base("aria2.changeUri", [gid, fileIndex, delUris, addUris, position])
+        /// <inheritdoc cref="IAria2Client.ChangeUri"/>
+        public ChangeUri(string gid, int fileIndex, IEnumerable<string> delUris, IEnumerable<string> addUris, int? position = null, string? id = null) : base("aria2.changeUri", [gid, fileIndex, delUris, addUris, position], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ForcePause.cs
+++ b/Aria2.JsonRpcClient/Requests/ForcePause.cs
@@ -5,8 +5,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record ForcePause : JsonRpcRequest<string>
     {
-        /// <inheritdoc cref="IAria2Client.ForcePause(string)"/>
-        public ForcePause(string gid) : base("aria2.forcePause", gid)
+        /// <inheritdoc cref="IAria2Client.ForcePause"/>
+        public ForcePause(string gid, string? id = null) : base("aria2.forcePause", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ForcePauseAll.cs
+++ b/Aria2.JsonRpcClient/Requests/ForcePauseAll.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record ForcePauseAll : JsonRpcRequest
     {
         /// <inheritdoc cref="IAria2Client.ForcePauseAll"/>
-        public ForcePauseAll() : base("aria2.forcePauseAll", JsonRpcParameters.Empty)
+        public ForcePauseAll(string? id = null) : base("aria2.forcePauseAll", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ForceRemove.cs
+++ b/Aria2.JsonRpcClient/Requests/ForceRemove.cs
@@ -5,8 +5,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record ForceRemove : JsonRpcRequest<string>
     {
-        /// <inheritdoc cref="IAria2Client.ForceRemove(string)"/>
-        public ForceRemove(string gid) : base("aria2.forceRemove", gid)
+        /// <inheritdoc cref="IAria2Client.ForceRemove"/>
+        public ForceRemove(string gid, string? id = null) : base("aria2.forceRemove", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ForceShutdown.cs
+++ b/Aria2.JsonRpcClient/Requests/ForceShutdown.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record ForceShutdown : JsonRpcRequest
     {
         /// <inheritdoc cref="IAria2Client.ForceShutdown"/>/>
-        public ForceShutdown() : base("aria2.forceShutdown", JsonRpcParameters.Empty)
+        public ForceShutdown(string? id = null) : base("aria2.forceShutdown", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetFiles.cs
+++ b/Aria2.JsonRpcClient/Requests/GetFiles.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record GetFiles : JsonRpcRequest<IReadOnlyList<Aria2File>>
     {
-        /// <inheritdoc cref="IAria2Client.GetFiles(string)"/>
-        public GetFiles(string gid) : base("aria2.getFiles", gid)
+        /// <inheritdoc cref="IAria2Client.GetFiles"/>
+        public GetFiles(string gid, string? id = null) : base("aria2.getFiles", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetGlobalOption.cs
+++ b/Aria2.JsonRpcClient/Requests/GetGlobalOption.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record GetGlobalOption : JsonRpcRequest<IReadOnlyDictionary<string, string?>>
     {
         /// <inheritdoc cref="IAria2Client.GetGlobalOption"/>
-        public GetGlobalOption() : base("aria2.getGlobalOption", JsonRpcParameters.Empty)
+        public GetGlobalOption(string? id = null) : base("aria2.getGlobalOption", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetGlobalStat.cs
+++ b/Aria2.JsonRpcClient/Requests/GetGlobalStat.cs
@@ -8,7 +8,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record GetGlobalStat : JsonRpcRequest<Aria2GlobalStat>
     {
         /// <inheritdoc cref="IAria2Client.GetGlobalStat"/>
-        public GetGlobalStat() : base("aria2.getGlobalStat", JsonRpcParameters.Empty)
+        public GetGlobalStat(string? id = null) : base("aria2.getGlobalStat", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetOption.cs
+++ b/Aria2.JsonRpcClient/Requests/GetOption.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record GetOption : JsonRpcRequest<Aria2Option>
     {
-        /// <inheritdoc cref="IAria2Client.GetOption(string)"/>
-        public GetOption(string gid) : base("aria2.getOption", gid)
+        /// <inheritdoc cref="IAria2Client.GetOption"/>
+        public GetOption(string gid, string? id = null) : base("aria2.getOption", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetPeers.cs
+++ b/Aria2.JsonRpcClient/Requests/GetPeers.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record GetPeers : JsonRpcRequest<IReadOnlyList<Aria2Peer>>
     {
-        /// <inheritdoc cref="IAria2Client.GetPeers(string)"/>
-        public GetPeers(string gid) : base("aria2.getPeers", gid)
+        /// <inheritdoc cref="IAria2Client.GetPeers"/>
+        public GetPeers(string gid, string? id = null) : base("aria2.getPeers", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetServers.cs
+++ b/Aria2.JsonRpcClient/Requests/GetServers.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record GetServers : JsonRpcRequest<IReadOnlyList<Aria2Server>>
     {
-        /// <inheritdoc cref="IAria2Client.GetServers(string)"/>
-        public GetServers(string gid) : base("aria2.getServers", gid)
+        /// <inheritdoc cref="IAria2Client.GetServers"/>
+        public GetServers(string gid, string? id = null) : base("aria2.getServers", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetSessionInfo.cs
+++ b/Aria2.JsonRpcClient/Requests/GetSessionInfo.cs
@@ -8,7 +8,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record GetSessionInfo : JsonRpcRequest<Aria2SessionInfo>
     {
         /// <inheritdoc cref="IAria2Client.GetSessionInfo"/>
-        public GetSessionInfo() : base("aria2.getSessionInfo", JsonRpcParameters.Empty)
+        public GetSessionInfo(string? id = null) : base("aria2.getSessionInfo", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetUris.cs
+++ b/Aria2.JsonRpcClient/Requests/GetUris.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record GetUris : JsonRpcRequest<IReadOnlyList<Aria2Uri>>
     {
-        /// <inheritdoc cref="IAria2Client.GetUris(string)"/>
-        public GetUris(string gid) : base("aria2.getUris", gid)
+        /// <inheritdoc cref="IAria2Client.GetUris"/>
+        public GetUris(string gid, string? id = null) : base("aria2.getUris", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/GetVersion.cs
+++ b/Aria2.JsonRpcClient/Requests/GetVersion.cs
@@ -8,7 +8,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record GetVersion : JsonRpcRequest<Aria2Version>
     {
         /// <inheritdoc cref="IAria2Client.GetVersion"/>
-        public GetVersion() : base("aria2.getVersion", JsonRpcParameters.Empty)
+        public GetVersion(string? id = null) : base("aria2.getVersion", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ListMethods.cs
+++ b/Aria2.JsonRpcClient/Requests/ListMethods.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record ListMethods : JsonRpcRequest<IReadOnlyList<string>>
     {
         /// <inheritdoc cref="IAria2Client.SystemListMethods"/>/>
-        public ListMethods() : base("system.listMethods", JsonRpcParameters.Empty)
+        public ListMethods(string? id = null) : base("system.listMethods", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/ListNotifications.cs
+++ b/Aria2.JsonRpcClient/Requests/ListNotifications.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record ListNotifications : JsonRpcRequest<IReadOnlyList<string>>
     {
         /// <inheritdoc cref="IAria2Client.SystemListNotifications"/>/>
-        public ListNotifications() : base("system.listNotifications", JsonRpcParameters.Empty)
+        public ListNotifications(string? id = null) : base("system.listNotifications", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/MultiCall.cs
+++ b/Aria2.JsonRpcClient/Requests/MultiCall.cs
@@ -8,8 +8,13 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record MultiCall : JsonRpcRequest<IReadOnlyList<JsonElement[]>>
     {
+        /// <inheritdoc cref="IAria2Client.SystemMulticall(JsonRpcRequest[], string?)"/>/>
+        public MultiCall(JsonRpcRequest[] requests, string? id = null) : base("system.multicall", [requests.Select(MapRequest).ToArray()], id)
+        {
+        }
+
         /// <inheritdoc cref="IAria2Client.SystemMulticall(JsonRpcRequest[])"/>/>
-        public MultiCall(JsonRpcRequest[] requests) : base("system.multicall", [requests.Select(MapRequest).ToArray()])
+        public MultiCall(params JsonRpcRequest[] requests) : this(requests, null)
         {
         }
 

--- a/Aria2.JsonRpcClient/Requests/Pause.cs
+++ b/Aria2.JsonRpcClient/Requests/Pause.cs
@@ -5,8 +5,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record Pause : JsonRpcRequest<string>
     {
-        /// <inheritdoc cref="IAria2Client.Pause(string)"/>
-        public Pause(string gid) : base("aria2.pause", gid)
+        /// <inheritdoc cref="IAria2Client.Pause"/>
+        public Pause(string gid, string? id = null) : base("aria2.pause", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/PauseAll.cs
+++ b/Aria2.JsonRpcClient/Requests/PauseAll.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record PauseAll : JsonRpcRequest
     {
         /// <inheritdoc cref="IAria2Client.PauseAll"/>
-        public PauseAll() : base("aria2.pauseAll", JsonRpcParameters.Empty)
+        public PauseAll(string? id = null) : base("aria2.pauseAll", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/PurgeDownloadResult.cs
+++ b/Aria2.JsonRpcClient/Requests/PurgeDownloadResult.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record PurgeDownloadResult : JsonRpcRequest
     {
         /// <inheritdoc cref="IAria2Client.PurgeDownloadResult"/>/>
-        public PurgeDownloadResult() : base("aria2.purgeDownloadResult", JsonRpcParameters.Empty)
+        public PurgeDownloadResult(string? id = null) : base("aria2.purgeDownloadResult", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/Remove.cs
+++ b/Aria2.JsonRpcClient/Requests/Remove.cs
@@ -5,8 +5,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record Remove : JsonRpcRequest<string>
     {
-        /// <inheritdoc cref="IAria2Client.Remove(string)"/>
-        public Remove(string gid) : base("aria2.remove", gid)
+        /// <inheritdoc cref="IAria2Client.Remove"/>
+        public Remove(string gid, string? id = null) : base("aria2.remove", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/RemoveDownloadResult.cs
+++ b/Aria2.JsonRpcClient/Requests/RemoveDownloadResult.cs
@@ -5,8 +5,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record RemoveDownloadResult : JsonRpcRequest
     {
-        /// <inheritdoc cref="IAria2Client.RemoveDownloadResult(string)"/>/>
-        public RemoveDownloadResult(string gid) : base("aria2.removeDownloadResult", gid)
+        /// <inheritdoc cref="IAria2Client.RemoveDownloadResult"/>/>
+        public RemoveDownloadResult(string gid, string? id = null) : base("aria2.removeDownloadResult", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/SaveSession.cs
+++ b/Aria2.JsonRpcClient/Requests/SaveSession.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record SaveSession : JsonRpcRequest
     {
         /// <inheritdoc cref="IAria2Client.SaveSession"/>/>
-        public SaveSession() : base("aria2.saveSession", JsonRpcParameters.Empty)
+        public SaveSession(string? id = null) : base("aria2.saveSession", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/Shutdown.cs
+++ b/Aria2.JsonRpcClient/Requests/Shutdown.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record Shutdown : JsonRpcRequest
     {
         /// <inheritdoc cref="IAria2Client.Shutdown"/>/>
-        public Shutdown() : base("aria2.shutdown", JsonRpcParameters.Empty)
+        public Shutdown(string? id = null) : base("aria2.shutdown", JsonRpcParameters.Empty, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/TellActive.cs
+++ b/Aria2.JsonRpcClient/Requests/TellActive.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record TellActive : JsonRpcRequest<IReadOnlyList<Aria2Status>>
     {
-        /// <inheritdoc cref="IAria2Client.TellActive(string[])"/>
-        public TellActive(string[]? keys = null) : base("aria2.tellActive", [keys])
+        /// <inheritdoc cref="IAria2Client.TellActive"/>
+        public TellActive(string[]? keys = null, string? id = null) : base("aria2.tellActive", [keys], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/TellStatus.cs
+++ b/Aria2.JsonRpcClient/Requests/TellStatus.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record TellStatus : JsonRpcRequest<Aria2Status>
     {
-        /// <inheritdoc cref="IAria2Client.TellStatus(string, string[])"/>
-        public TellStatus(string gid, string[]? keys = null) : base("aria2.tellStatus", [gid, keys])
+        /// <inheritdoc cref="IAria2Client.TellStatus"/>
+        public TellStatus(string gid, string[]? keys = null, string? id = null) : base("aria2.tellStatus", [gid, keys], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/TellStopped.cs
+++ b/Aria2.JsonRpcClient/Requests/TellStopped.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record TellStopped : JsonRpcRequest<IReadOnlyList<Aria2Status>>
     {
-        /// <inheritdoc cref="IAria2Client.TellStopped(int, int, string[])"/>
-        public TellStopped(int offset, int num, string[]? keys = null) : base("aria2.tellStopped", [offset, num, keys])
+        /// <inheritdoc cref="IAria2Client.TellStopped"/>
+        public TellStopped(int offset, int num, string[]? keys = null, string? id = null) : base("aria2.tellStopped", [offset, num, keys], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/TellWaiting.cs
+++ b/Aria2.JsonRpcClient/Requests/TellWaiting.cs
@@ -7,8 +7,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record TellWaiting : JsonRpcRequest<IReadOnlyList<Aria2Status>>
     {
-        /// <inheritdoc cref="IAria2Client.TellWaiting(int, int, string[])"/>
-        public TellWaiting(int offset, int num, string[]? keys = null) : base("aria2.tellWaiting", [offset, num, keys])
+        /// <inheritdoc cref="IAria2Client.TellWaiting"/>
+        public TellWaiting(int offset, int num, string[]? keys = null, string? id = null) : base("aria2.tellWaiting", [offset, num, keys], id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/Unpause.cs
+++ b/Aria2.JsonRpcClient/Requests/Unpause.cs
@@ -5,8 +5,8 @@ namespace Aria2.JsonRpcClient.Requests
     /// </summary>
     public sealed record Unpause : JsonRpcRequest<string>
     {
-        /// <inheritdoc cref="IAria2Client.Unpause(string)"/>
-        public Unpause(string gid) : base("aria2.unpause", gid)
+        /// <inheritdoc cref="IAria2Client.Unpause"/>
+        public Unpause(string gid, string? id = null) : base("aria2.unpause", gid, id)
         {
         }
     }

--- a/Aria2.JsonRpcClient/Requests/UnpauseAll.cs
+++ b/Aria2.JsonRpcClient/Requests/UnpauseAll.cs
@@ -6,7 +6,7 @@ namespace Aria2.JsonRpcClient.Requests
     public sealed record UnpauseAll : JsonRpcRequest
     {
         /// <inheritdoc cref="IAria2Client.UnpauseAll"/>
-        public UnpauseAll() : base("aria2.unpauseAll", JsonRpcParameters.Empty)
+        public UnpauseAll(string? id = null) : base("aria2.unpauseAll", JsonRpcParameters.Empty, id)
         {
         }
     }


### PR DESCRIPTION
Allows the Json RPC id field to be manually set to override the default guid to string ids.